### PR TITLE
Update docker-compose.yml fixes #16 invalid boolean value

### DIFF
--- a/examples/strapi-postgres/docker-compose.yml
+++ b/examples/strapi-postgres/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       DATABASE_NAME: postgres
       DATABASE_USERNAME: postgres
       DATABASE_PASSWORD: postgres
-      DATABASE_SSL: false # boolean for SSL.
+      DATABASE_SSL: 'false' # boolean for SSL.
     volumes:
       - app:/srv/app # create a new project in app volume
   postgres:


### PR DESCRIPTION
Fixes:
ERROR: The Compose file './docker-compose.yaml' is invalid because: services.strapi-v4.environment.DATABASE_SSL contains false, which is an invalid type, it should be a string, number, or a null